### PR TITLE
fix badge positioning inside of custom element

### DIFF
--- a/paper-badge.html
+++ b/paper-badge.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 
 <!--
@@ -56,6 +57,7 @@ Custom property | Description | Default
       display: block;
       position: absolute;
       outline: none;
+      z-index: 1002;
     }
 
     #badge {
@@ -67,12 +69,12 @@ Custom property | Description | Default
       margin-bottom: var(--paper-badge-margin-bottom, 0px);
       width: var(--paper-badge-width, 22px);
       height: var(--paper-badge-height, 22px);
-      display: flex;
-      justify-content: center;
-      align-items: center;
       background-color: var(--paper-badge-background, --accent-color);
       opacity: var(--paper-badge-opacity, 1.0);
       color: var(--paper-badge-text-color, white);
+      @apply(--layout);
+      @apply(--layout-center-center);
+
       @apply(--paper-badge);
     }
   </style>
@@ -88,7 +90,7 @@ Custom property | Description | Default
       ],
 
       listeners: {
-        'iron-resize': '_onIronResize'
+        'iron-resize': '_setPosition'
       },
 
       properties: {
@@ -97,7 +99,8 @@ Custom property | Description | Default
          * must be a sibling of the badge.
          */
         for: {
-          type: String
+          type: String,
+          observer: '_forChanged'
         },
 
         /**
@@ -110,6 +113,19 @@ Custom property | Description | Default
       },
 
       attached: function() {
+        this._updateTarget();
+      },
+
+      _forChanged: function() {
+        // The first time the property is set is before the badge is attached,
+        // which means we're not ready to position it yet.
+        if (!this.isAttached) {
+          return;
+        }
+        this._updateTarget();
+      },
+
+      _updateTarget: function() {
         this._target = this.target;
         this.async(this.notifyResize, 1);
       },
@@ -120,23 +136,19 @@ Custom property | Description | Default
        * of the badge.
        */
       get target () {
-        var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var parentNode = Polymer.dom(this).parentNode;
+        // If the parentNode is a document fragment, then we need to use the host.
+        var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var target;
 
         if (this.for) {
-          target = parentNode.querySelector('#' + this.for);
-        } else if (parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
-          target = ownerRoot.host;
+          target = Polymer.dom(ownerRoot).querySelector('#' + this.for);
         } else {
-          target = parentNode;
+          target = parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
+              ownerRoot.host : parentNode;
         }
 
         return target;
-      },
-
-      _onIronResize: function() {
-        this._setPosition();
       },
 
       _setPosition: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -20,6 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-badge.html">
+  <link rel="import" href="test-button.html">
 
 </head>
 <style>
@@ -44,20 +45,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="dynamic">
+    <template>
+      <div>
+        <div id="target"></div>
+        <paper-badge label="1"></paper-badge>
+      </div>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="custom">
+    <template>
+      <test-button></test-button>
+    </template>
+  </test-fixture>
+
   <script>
     suite('basic', function() {
-      test('badge is shown', function() {
-        var f = fixture('basic');
-        var badge = f.querySelector('paper-badge');
-        var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
-
-        assert.isFalse(actualbadge.hidden);
-        assert.equal(actualbadge.textContent, "1");
-      });
-
       test('badge is positioned correctly', function(done) {
         var f = fixture('basic');
         var badge = f.querySelector('paper-badge');
+        var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
+        assert.equal(actualbadge.textContent, "1");
+
         badge._setPosition();
 
         Polymer.Base.async(function() {
@@ -79,6 +89,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(contentRect.top).to.be.equal(divRect.top - 11);
 
           done();
+        });
+      });
+
+      test('badge is positioned correctly after being dynamically set', function(done) {
+        var f = fixture('dynamic');
+        var badge = f.querySelector('paper-badge');
+        badge._setPosition();
+
+        Polymer.Base.async(function() {
+          var contentRect = badge.getBoundingClientRect();
+          expect(contentRect.left).to.not.be.equal(100 - 11);
+
+          badge.for = 'target';
+          badge._setPosition();
+
+          Polymer.Base.async(function() {
+            var divRect = f.querySelector('#target').getBoundingClientRect();
+            expect(divRect.width).to.be.equal(100);
+            expect(divRect.height).to.be.equal(20);
+
+            var contentRect = badge.getBoundingClientRect();
+            expect(contentRect.width).to.be.equal(22);
+            expect(contentRect.height).to.be.equal(22);
+
+            // The target div is 100 x 20, and the badge is centered on the
+            // top right corner.
+            expect(contentRect.left).to.be.equal(100 - 11);
+            expect(contentRect.top).to.be.equal(0 - 11);
+
+            // Also check the math, just in case.
+            expect(contentRect.left).to.be.equal(divRect.width - 11);
+            expect(contentRect.top).to.be.equal(divRect.top - 11);
+
+            done();
+          });
+        });
+      });
+
+      suite('badge is inside a custom element', function() {
+        test('badge is positioned correctly', function(done) {
+          var f = fixture('custom');
+          var badge = f.$.badge;
+          var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
+          assert.equal(actualbadge.textContent, "1");
+
+          badge._setPosition();
+
+          Polymer.Base.async(function() {
+            var divRect = f.$.button.getBoundingClientRect();
+            expect(divRect.width).to.be.equal(100);
+            expect(divRect.height).to.be.equal(20);
+
+            var contentRect = badge.getBoundingClientRect();
+            expect(contentRect.width).to.be.equal(22);
+            expect(contentRect.height).to.be.equal(22);
+
+            // The target div is 100 x 20, and the badge is centered on the
+            // top right corner.
+            expect(contentRect.left).to.be.equal(100 - 11);
+            expect(contentRect.top).to.be.equal(0 - 11);
+
+            // Also check the math, just in case.
+            expect(contentRect.left).to.be.equal(divRect.width - 11);
+            expect(contentRect.top).to.be.equal(divRect.top - 11);
+
+            done();
+          });
         });
       });
     });

--- a/test/test-button.html
+++ b/test/test-button.html
@@ -9,30 +9,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../../iron-icons/iron-icons.html">
-<link rel="import" href="../../paper-styles/color.html">
 <link rel="import" href="../paper-badge.html">
 
 <dom-module id="test-button">
   <style>
     :host {
       display: inline-block;
-      position: relative;
     }
 
-    paper-icon-button {
-      padding: 0;
-      margin: 0;
+    #button {
+      width: 100px;
+      height: 20px;
+      background-color: red;
     }
 
-    paper-badge {
-      --paper-badge-background: var(--paper-light-blue-300);
-    }
   </style>
   <template>
-      <paper-icon-button id="button" icon="menu" alt="menu"></paper-icon-button>
-      <paper-badge for="button" label="♠︎"></paper-badge>
+    <div id="button"></div>
+    <paper-badge id="badge" for="button" label="1"></paper-badge>
   </template>
 
   <script>


### PR DESCRIPTION
This is exactly the same fix that was needed for https://github.com/PolymerElements/paper-tooltip/pull/17

Also added tests to make sure the badge is positioned correctly when used inside a custom element (and confirmed they were failing before this patch).

I feel the contents of the `_setPosition` function should be in a helper method somewhere, but this somewhere doesn't exist so they're kinda 100% copy pasted. Sigh.

/cc @morethanreal @cdata 