### PR TITLE
make the updatePosition method public

### DIFF
--- a/paper-badge.html
+++ b/paper-badge.html
@@ -89,7 +89,7 @@ Custom property | Description | Default
       ],
 
       listeners: {
-        'iron-resize': '_setPosition'
+        'iron-resize': 'updatePosition'
       },
 
       properties: {
@@ -150,8 +150,21 @@ Custom property | Description | Default
         return target;
       },
 
-      _setPosition: function() {
+      /**
+       * Repositions the badge relative to its anchor element. This is called
+       * automatically when the badge is attached or an `iron-resize` event is
+       * fired (for exmaple if the window has resized, or your target is a
+       * custom element that implements IronResizableBehavior).
+       *
+       * You should call this in all other cases when the achor's position
+       * might have changed (for example, if it's visibility has changed, or
+       * you've manually done a page re-layout).
+       */
+      updatePosition: function() {
         if (!this._target)
+          return;
+
+        if (!this.offsetParent)
           return;
 
         var parentRect = this.offsetParent.getBoundingClientRect();

--- a/test/basic.html
+++ b/test/basic.html
@@ -68,7 +68,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
         assert.equal(actualbadge.textContent, "1");
 
-        badge._setPosition();
+        badge.updatePosition();
 
         Polymer.Base.async(function() {
           var divRect = f.querySelector('#target').getBoundingClientRect();
@@ -95,14 +95,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('badge is positioned correctly after being dynamically set', function(done) {
         var f = fixture('dynamic');
         var badge = f.querySelector('paper-badge');
-        badge._setPosition();
+        badge.updatePosition();
 
         Polymer.Base.async(function() {
           var contentRect = badge.getBoundingClientRect();
           expect(contentRect.left).to.not.be.equal(100 - 11);
 
           badge.for = 'target';
-          badge._setPosition();
+          badge.updatePosition();
 
           Polymer.Base.async(function() {
             var divRect = f.querySelector('#target').getBoundingClientRect();
@@ -134,7 +134,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
           assert.equal(actualbadge.textContent, "1");
 
-          badge._setPosition();
+          badge.updatePosition();
 
           Polymer.Base.async(function() {
             var divRect = f.$.button.getBoundingClientRect();


### PR DESCRIPTION
- Fixes https://github.com/PolymerElements/paper-badge/issues/8: if the `parentOffset` doesn't exist, don't try to reposition the badge
- Fixes https://github.com/PolymerElements/paper-badge/issues/3 which is the above fix, as well as aking the `_setPosition` method public

👉@cdata