### PR TITLE
Configure NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components/
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,34 +1,8 @@
 {
-  "name": "paper-badge",
-  "version": "1.0.3",
-  "description": "Material design status message for elements",
-  "main": [
-    "paper-badge.html"
-  ],
-  "directories": {
-    "test": "test"
-  },
   "dependencies": {
-    "express": "^4.12.3",
     "web-component-tester": "git://github.com/polymer/web-component-tester.git"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "./node_modules/web-component-tester/bin/wct"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/PolymerElements/paper-badge.git"
-  },
-  "keywords": [
-    "web-components",
-    "polymer",
-    "badge",
-    "notification"
-  ],
-  "license": "http://polymer.github.io/LICENSE.txt",
-  "bugs": {
-    "url": "https://github.com/PolymerElements/paper-badge/issues"
-  },
-  "homepage": "https://github.com/PolymerElements/paper-badge"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "paper-badge",
+  "version": "1.0.3",
+  "description": "Material design status message for elements",
+  "main": [
+    "paper-badge.html"
+  ],
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "express": "^4.12.3",
+    "web-component-tester": "git://github.com/polymer/web-component-tester.git"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "./node_modules/web-component-tester/bin/wct"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PolymerElements/paper-badge.git"
+  },
+  "keywords": [
+    "web-components",
+    "polymer",
+    "badge",
+    "notification"
+  ],
+  "license": "http://polymer.github.io/LICENSE.txt",
+  "bugs": {
+    "url": "https://github.com/PolymerElements/paper-badge/issues"
+  },
+  "homepage": "https://github.com/PolymerElements/paper-badge"
+}


### PR DESCRIPTION
The NPM configuration `package.json` references [web-components-tester](github.com/polymer/web-component-tester) dependency, so that `wtc` can be used to execute unit-tests. `npm test` can also be used to run the tests.