### PR TITLE
hide paper-badge until position is calculated

### DIFF
--- a/paper-badge.html
+++ b/paper-badge.html
@@ -70,6 +70,12 @@ Custom property | Description | Default
         display: block;
         position: absolute;
         outline: none;
+        opacity: 0;
+        background: blue;
+      }
+
+      :host(.visible) {
+        opacity: 1;
       }
 
       :host([hidden]) {
@@ -96,7 +102,8 @@ Custom property | Description | Default
         background-color: var(--paper-badge-background, --accent-color);
         opacity: var(--paper-badge-opacity, 1.0);
         color: var(--paper-badge-text-color, white);
-
+        @apply(--layout);
+        @apply(--layout-center-center);
         @apply(--paper-badge);
       }
     </style>
@@ -229,6 +236,7 @@ Custom property | Description | Default
         var targetRect = this._target.getBoundingClientRect();
         var thisRect = this.getBoundingClientRect();
 
+        this.classList.add('visible');
         this.style.left = targetRect.left - parentRect.left +
             (targetRect.width - thisRect.width / 2) + 'px';
         this.style.top = targetRect.top - parentRect.top -

--- a/test/basic.html
+++ b/test/basic.html
@@ -85,6 +85,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="created">
+    <template>
+      <div>
+        <div id="target">Target</div>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     suite('basic', function() {
       test('badge is positioned correctly', function(done) {
@@ -239,37 +247,78 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
       });
+    });
 
-      suite('badge is inside a custom element', function() {
-        test('badge is positioned correctly', function(done) {
-          var f = fixture('custom');
-          var badge = f.$.badge;
-          var actualbadge = Polymer.dom(badge.root).querySelector('.badge');
+    suite('badge is created dynamicly', function() {
+      test('label is set properly', function(done) {
+        var dynamicBadge, actualbadge, testValue = '123';
+        dynamicBadge = document.createElement('paper-badge');
+        dynamicBadge.setAttribute('label', testValue);
+        actualbadge = Polymer.dom(dynamicBadge.root).querySelector('.badge');
 
-          badge.updatePosition();
+        Polymer.Base.async(function() {
+          assert.equal(actualbadge.textContent.trim(), testValue);
+          done();
+        });
+      });
 
+      test('badge is not visible until positioned', function(done) {
+        var dynamicBadge, actualbadge, f, target;
+
+        f = fixture('created');
+        dynamicBadge = document.createElement('paper-badge');
+        dynamicBadge.setAttribute('label', 1);
+        actualbadge = Polymer.dom(dynamicBadge.root).querySelector('.badge');
+
+        target = f.querySelector('#target');
+        target.appendChild(dynamicBadge);
+
+        Polymer.Base.async(function() {
+          expect(window.getComputedStyle(dynamicBadge).opacity).to.be.equal('0');
+          expect(dynamicBadge.getBoundingClientRect().left).to.be.equal(0);
+
+          dynamicBadge.updatePosition();
+          
           Polymer.Base.async(function() {
-            assert.equal(actualbadge.textContent.trim(), "1");
-
-            var divRect = f.$.button.getBoundingClientRect();
-            expect(divRect.width).to.be.equal(100);
-            expect(divRect.height).to.be.equal(20);
-
-            var contentRect = badge.getBoundingClientRect();
-            expect(contentRect.width).to.be.equal(20);
-            expect(contentRect.height).to.be.equal(20);
-
-            // The target div is 100 x 20, and the badge is centered on the
-            // top right corner.
-            expect(contentRect.left).to.be.equal(100 - 10);
-            expect(contentRect.top).to.be.equal(0 - 10);
-
-            // Also check the math, just in case.
-            expect(contentRect.left).to.be.equal(divRect.width - 10);
-            expect(contentRect.top).to.be.equal(divRect.top - 10);
-
+            expect(window.getComputedStyle(dynamicBadge).visibility).to.be.equal('visible');
+            expect(dynamicBadge.getBoundingClientRect().left).to.be.equal(100 - 10);
+            expect(dynamicBadge.className.indexOf('visible')).to.be.not.equal(-1);
+            expect(window.getComputedStyle(dynamicBadge).opacity).to.be.equal('1');
             done();
-          });
+          }, 15); // Safari needs some time to apply CSS styles
+        });
+      });
+    });
+
+    suite('badge is inside a custom element', function() {
+      test('badge is positioned correctly', function(done) {
+        var f = fixture('custom');
+        var badge = f.$.badge;
+        var actualbadge = Polymer.dom(badge.root).querySelector('.badge');
+
+        badge.updatePosition();
+
+        Polymer.Base.async(function() {
+          assert.equal(actualbadge.textContent.trim(), "1");
+
+          var divRect = f.$.button.getBoundingClientRect();
+          expect(divRect.width).to.be.equal(100);
+          expect(divRect.height).to.be.equal(20);
+
+          var contentRect = badge.getBoundingClientRect();
+          expect(contentRect.width).to.be.equal(20);
+          expect(contentRect.height).to.be.equal(20);
+
+          // The target div is 100 x 20, and the badge is centered on the
+          // top right corner.
+          expect(contentRect.left).to.be.equal(100 - 10);
+          expect(contentRect.top).to.be.equal(0 - 10);
+
+          // Also check the math, just in case.
+          expect(contentRect.left).to.be.equal(divRect.width - 10);
+          expect(contentRect.top).to.be.equal(divRect.top - 10);
+
+          done();
         });
       });
     });


### PR DESCRIPTION
Between rendering `paper-badge` and the `updatePosition()` call (triggered by the `iron-resize` event) the badge is displayed at the wrong location for a short moment.

This issue was first seen when rendering a huge document with attached paper-badges, so that the effect might stay invisible until `updatePosition()` was not called fast enough. The unit-test "__badge is not visible until positioned__" tests if the element's visibility style is hidden until it's position was updated.

##### Screen-Recording taken with Chrome 43.0.2357.134:
![paper-badge-flicker](https://cloud.githubusercontent.com/assets/473924/9410100/a003f668-481e-11e5-9d0b-4ce6915080ad.gif)
