### PR TITLE
Update default paper-badge styles.

### DIFF
--- a/paper-badge.html
+++ b/paper-badge.html
@@ -40,8 +40,8 @@ Custom property | Description | Default
 `--paper-badge-background` | The background color of the badge | `--accent-color`
 `--paper-badge-opacity` | The opacity of the badge | `1.0`
 `--paper-badge-text-color` | The color of the badge text | `white`
-`--paper-badge-width` | The width of the badge circle | `22px`
-`--paper-badge-height` | The height of the badge circle | `22px`
+`--paper-badge-width` | The width of the badge circle | `20px`
+`--paper-badge-height` | The height of the badge circle | `20px`
 `--paper-badge-margin-left` | Optional spacing added to the left of the badge. | `0px`
 `--paper-badge-margin-bottom` | Optional spacing added to the bottom of the badge. | `0px`
 `--paper-badge` | Mixin applied to the badge | `{}`
@@ -62,13 +62,13 @@ Custom property | Description | Default
 
       #badge {
         @apply(--paper-font-common-base);
-        font-weight: 600;
-        font-size: 12px;
+        font-weight: normal;
+        font-size: 11px;
         border-radius: 50%;
         margin-left: var(--paper-badge-margin-left, 0px);
         margin-bottom: var(--paper-badge-margin-bottom, 0px);
-        width: var(--paper-badge-width, 22px);
-        height: var(--paper-badge-height, 22px);
+        width: var(--paper-badge-width, 20px);
+        height: var(--paper-badge-height, 20px);
         background-color: var(--paper-badge-background, --accent-color);
         opacity: var(--paper-badge-opacity, 1.0);
         color: var(--paper-badge-text-color, white);

--- a/test/basic.html
+++ b/test/basic.html
@@ -88,17 +88,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(divRect.height).to.be.equal(20);
 
           var contentRect = badge.getBoundingClientRect();
-          expect(contentRect.width).to.be.equal(22);
-          expect(contentRect.height).to.be.equal(22);
+          expect(contentRect.width).to.be.equal(20);
+          expect(contentRect.height).to.be.equal(20);
 
           // The target div is 100 x 20, and the badge is centered on the
           // top right corner.
-          expect(contentRect.left).to.be.equal(100 - 11);
-          expect(contentRect.top).to.be.equal(0 - 11);
+          expect(contentRect.left).to.be.equal(100 - 10);
+          expect(contentRect.top).to.be.equal(0 - 10);
 
           // Also check the math, just in case.
-          expect(contentRect.left).to.be.equal(divRect.width - 11);
-          expect(contentRect.top).to.be.equal(divRect.top - 11);
+          expect(contentRect.left).to.be.equal(divRect.width - 10);
+          expect(contentRect.top).to.be.equal(divRect.top - 10);
 
           done();
         });
@@ -126,17 +126,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(divRect.height).to.be.equal(20);
 
             var contentRect = badge.getBoundingClientRect();
-            expect(contentRect.width).to.be.equal(22);
-            expect(contentRect.height).to.be.equal(22);
+            expect(contentRect.width).to.be.equal(20);
+            expect(contentRect.height).to.be.equal(20);
 
             // The target div is 100 x 20, and the badge is centered on the
             // top right corner.
-            expect(contentRect.left).to.be.equal(100 - 11);
-            expect(contentRect.top).to.be.equal(0 - 11);
+            expect(contentRect.left).to.be.equal(100 - 10);
+            expect(contentRect.top).to.be.equal(0 - 10);
 
             // Also check the math, just in case.
-            expect(contentRect.left).to.be.equal(divRect.width - 11);
-            expect(contentRect.top).to.be.equal(divRect.top - 11);
+            expect(contentRect.left).to.be.equal(divRect.width - 10);
+            expect(contentRect.top).to.be.equal(divRect.top - 10);
 
             done();
           });
@@ -157,17 +157,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(divRect.height).to.be.equal(20);
 
           var contentRect = badge.getBoundingClientRect();
-          expect(contentRect.width).to.be.equal(22);
-          expect(contentRect.height).to.be.equal(22);
+          expect(contentRect.width).to.be.equal(20);
+          expect(contentRect.height).to.be.equal(20);
 
           // The target div is 100 x 20, and the badge is centered on the
           // top right corner.
-          expect(contentRect.left).to.be.equal(100 - 11);
-          expect(contentRect.top).to.be.equal(0 - 11);
+          expect(contentRect.left).to.be.equal(100 - 10);
+          expect(contentRect.top).to.be.equal(0 - 10);
 
           // Also check the math, just in case.
-          expect(contentRect.left).to.be.equal(divRect.width - 11);
-          expect(contentRect.top).to.be.equal(divRect.top - 11);
+          expect(contentRect.left).to.be.equal(divRect.width - 10);
+          expect(contentRect.top).to.be.equal(divRect.top - 10);
 
           done();
         });
@@ -188,17 +188,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(divRect.height).to.be.equal(20);
 
             var contentRect = badge.getBoundingClientRect();
-            expect(contentRect.width).to.be.equal(22);
-            expect(contentRect.height).to.be.equal(22);
+            expect(contentRect.width).to.be.equal(20);
+            expect(contentRect.height).to.be.equal(20);
 
             // The target div is 100 x 20, and the badge is centered on the
             // top right corner.
-            expect(contentRect.left).to.be.equal(100 - 11);
-            expect(contentRect.top).to.be.equal(0 - 11);
+            expect(contentRect.left).to.be.equal(100 - 10);
+            expect(contentRect.top).to.be.equal(0 - 10);
 
             // Also check the math, just in case.
-            expect(contentRect.left).to.be.equal(divRect.width - 11);
-            expect(contentRect.top).to.be.equal(divRect.top - 11);
+            expect(contentRect.left).to.be.equal(divRect.width - 10);
+            expect(contentRect.top).to.be.equal(divRect.top - 10);
 
             done();
           });


### PR DESCRIPTION
This commit modifies the default styles of badges in the following way:

* Sets the default width/height of the badge to 20px
* Sets the font size to 11px
* Sets the font weight to normal

These changes were made in collaboration with the designers from the
Material Design team.