### PR TITLE
Add support for icons within badges

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-styles/color.html">
   <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../../iron-icons/iron-icons.html">
+  <link rel="import" href="../../iron-icons/social-icons.html">
   <link rel="import" href="../paper-badge.html">
   <link rel="import" href="test-button.html">
 
@@ -103,6 +104,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         <paper-icon-button id="fwd" icon="arrow-forward" alt="go forward"></paper-icon-button>
         <paper-badge class="green" for="fwd" label="♦︎"></paper-badge>
+      </div>
+    </div>
+    <div>
+      <h4>Using icon badges</h4>
+      <div class="horizontal-section">
+        <paper-icon-button id="home" icon="home" alt="home"></paper-icon-button>
+        <paper-badge icon="favorite" for="home" label="favorite icon"></paper-badge>
+
+        <paper-icon-button id="account-box" icon="account-box" alt="account-box"></paper-icon-button>
+        <paper-badge icon="social:mood" for="account-box" label="mood icon"></paper-badge>
       </div>
     </div>
   </div>

--- a/paper-badge.html
+++ b/paper-badge.html
@@ -19,6 +19,12 @@ corner of an element, representing a status or a notification. It will badge
 the anchor element specified in the `for` attribute, or, if that doesn't exist,
 centered to the parent node containing it.
 
+Badges can also contain an icon by adding the `icon` attribute and setting
+it to the id of the desired icon. Please note that you should still set the
+`label` attribute in order to keep the element accessible. Also note that you will need to import
+the `iron-iconset` that includes the icons you want to use. See [iron-icon](../iron-icon)
+for more information on how to import and use icon sets.
+
 Example:
 
     <div style="display:inline-block">
@@ -28,7 +34,12 @@ Example:
 
     <div>
       <paper-button id="btn">Status</paper-button>
-      <paper-badge for="btn" label="♥︎"></paper-badge>
+      <paper-badge icon="favorite" for="btn" label="favorite icon"></paper-badge>
+    </div>
+
+    <div>
+      <paper-icon-button id="account-box" icon="account-box" alt="account-box"></paper-icon-button>
+      <paper-badge icon="social:mood" for="account-box" label="mood icon"></paper-badge>
     </div>
 
 ### Styling
@@ -60,7 +71,12 @@ Custom property | Description | Default
         outline: none;
       }
 
-      #badge {
+      iron-icon {
+        --iron-icon-width: 12px;
+        --iron-icon-height: 12px;
+      }
+
+      .badge {
         @apply(--paper-font-common-base);
         font-weight: normal;
         font-size: 11px;
@@ -79,7 +95,10 @@ Custom property | Description | Default
       }
     </style>
 
-    <div id="badge">{{label}}</div>
+    <div class="badge">
+      <iron-icon hidden$="{{!_computeIsIconBadge(icon)}}" icon="{{icon}}"></iron-icon>
+      <span id="badge-text" hidden$="{{_computeIsIconBadge(icon)}}">{{label}}</span>
+    </div>
   </template>
 
   <script>
@@ -116,6 +135,17 @@ Custom property | Description | Default
         label: {
           type: String,
           observer: '_labelChanged'
+        },
+
+        /**
+         * An iron-icon ID. When given, the badge content will use an
+         * `<iron-icon>` element displaying the given icon ID rather than the
+         * label text. However, the label text will still be used for
+         * accessibility purposes.
+         */
+        icon: {
+          type: String,
+          value: ''
         }
       },
 
@@ -139,6 +169,10 @@ Custom property | Description | Default
       _updateTarget: function() {
         this._target = this.target;
         this.async(this.notifyResize, 1);
+      },
+
+      _computeIsIconBadge: function(icon) {
+        return icon.length > 0;
       },
 
       /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -70,19 +70,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="icon-badge">
+    <template>
+      <div style="position:relative">
+        <div id="target"></div>
+        <paper-badge icon="favorite" label="favorite icon"></paper-badge>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     suite('basic', function() {
       test('badge is positioned correctly', function(done) {
         var f = fixture('basic');
         var badge = f.querySelector('paper-badge');
-        var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
-        assert.equal(actualbadge.textContent, "1");
+        var actualbadge = Polymer.dom(badge.root).querySelector('.badge');
 
         expect(badge.target.getAttribute('id')).to.be.equal('target');
 
         badge.updatePosition();
 
         Polymer.Base.async(function() {
+          assert.equal(actualbadge.textContent.trim(), "1");
+
           var divRect = f.querySelector('#target').getBoundingClientRect();
           expect(divRect.width).to.be.equal(100);
           expect(divRect.height).to.be.equal(20);
@@ -143,7 +153,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-    test('badge is positioned correctly when nested in a target element', function(done) {
+      test('badge is positioned correctly when nested in a target element', function(done) {
         var f = fixture('nested');
         var badge = f.querySelector('paper-badge');
 
@@ -173,16 +183,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      test('badge displays icons correctly', function(done) {
+        var f = fixture('icon-badge');
+        var badge = f.querySelector('paper-badge');
+
+        Polymer.Base.async(function() {
+          var icon = Polymer.dom(badge.root).querySelector('iron-icon');
+          expect(icon).not.to.be.null;
+          expect(icon.icon).to.be.equal(badge.icon);
+          expect(badge.getAttribute('aria-label')).to.be.equal(badge.label);
+          done();
+        });
+      });
+
       suite('badge is inside a custom element', function() {
         test('badge is positioned correctly', function(done) {
           var f = fixture('custom');
           var badge = f.$.badge;
-          var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
-          assert.equal(actualbadge.textContent, "1");
+          var actualbadge = Polymer.dom(badge.root).querySelector('.badge');
 
           badge.updatePosition();
 
           Polymer.Base.async(function() {
+            assert.equal(actualbadge.textContent.trim(), "1");
+
             var divRect = f.$.button.getBoundingClientRect();
             expect(divRect.width).to.be.equal(100);
             expect(divRect.height).to.be.equal(20);


### PR DESCRIPTION
This commit adds a new attribute - `icon` - to `paper-badge`
elements that facilitate the placement of `iron-icon` elements within
badges. This allows clients to easily use icons without the need for
an additional element. According to the designers on the Material
Design team, icons within badges is a use case that should be
supported.