### PR TITLE
Remove div and add missed typography import

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/PolymerElements/paper-badge",
   "ignore": [],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.1.0",
+    "polymer": "Polymer/polymer#^1.2.0",
     "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0"
   },

--- a/demo/index.html
+++ b/demo/index.html
@@ -54,8 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     .with-badge > paper-badge {
-      --paper-badge-margin-left: 20px;
-      --paper-badge-margin-bottom: 0px;
+      --paper-badge-margin-left: 10px;
     }
   </style>
 </head>

--- a/paper-badge.html
+++ b/paper-badge.html
@@ -12,6 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/typography.html">
 
 <!--
 `<paper-badge>` is a circular text badge that is displayed on the top right
@@ -55,31 +56,28 @@ Custom property | Description | Default
   <template>
     <style>
       :host {
-        display: block;
-        position: absolute;
-        outline: none;
-      }
-
-      #badge {
-        @apply(--paper-font-common-base);
-        font-weight: normal;
-        font-size: 11px;
-        border-radius: 50%;
-        margin-left: var(--paper-badge-margin-left, 0px);
-        margin-bottom: var(--paper-badge-margin-bottom, 0px);
-        width: var(--paper-badge-width, 20px);
-        height: var(--paper-badge-height, 20px);
-        background-color: var(--paper-badge-background, --accent-color);
-        opacity: var(--paper-badge-opacity, 1.0);
-        color: var(--paper-badge-text-color, white);
         @apply(--layout);
         @apply(--layout-center-center);
+        @apply(--paper-font-common-base);
+
+        background-color: var(--paper-badge-background, --accent-color);
+        border-radius: 50%;
+        color: var(--paper-badge-text-color, white);
+        font-size: 11px;
+        font-weight: normal;
+        height: var(--paper-badge-height, 20px);
+        margin-bottom: var(--paper-badge-margin-bottom, 0px);
+        margin-left: var(--paper-badge-margin-left, 0px);
+        opacity: var(--paper-badge-opacity, 1.0);
+        outline: none;
+        position: absolute;
+        width: var(--paper-badge-width, 20px);
 
         @apply(--paper-badge);
       }
     </style>
 
-    <div id="badge">{{label}}</div>
+    {{label}}
   </template>
 
   <script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -75,8 +75,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('badge is positioned correctly', function(done) {
         var f = fixture('basic');
         var badge = f.querySelector('paper-badge');
-        var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
-        assert.equal(actualbadge.textContent, "1");
+        assert.equal(badge.textContent.trim(), '1');
 
         expect(badge.target.getAttribute('id')).to.be.equal('target');
 
@@ -143,7 +142,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-    test('badge is positioned correctly when nested in a target element', function(done) {
+      test('badge is positioned correctly when nested in a target element', function(done) {
         var f = fixture('nested');
         var badge = f.querySelector('paper-badge');
 
@@ -177,8 +176,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('badge is positioned correctly', function(done) {
           var f = fixture('custom');
           var badge = f.$.badge;
-          var actualbadge = Polymer.dom(badge.root).querySelector('#badge');
-          assert.equal(actualbadge.textContent, "1");
+          assert.equal(badge.textContent.trim(), '1');
 
           badge.updatePosition();
 


### PR DESCRIPTION
- Remove the `<div id="badge"></div>` tag because in Polymer 1.2.0 it is not necessary.

- Add the missed `paper-styles/typography.html` used in the `--paper-font-common-base` mixin.