### PR TITLE
Use superscript as badge's default positioning.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -75,11 +75,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             margin-left: 30px;
             margin-right: 30px;
           }
-          /* Need to position the badge to look like a text superscript */
-          .container > paper-badge {
-            --paper-badge-margin-left: 20px;
-            --paper-badge-margin-bottom: 0px;
-          }
         </style>
       </template>
     </demo-snippet>

--- a/demo/index.html
+++ b/demo/index.html
@@ -59,12 +59,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h3>Badges can be applied to direct siblings</h3>
     <demo-snippet class="centered-demo">
       <template>
-        <div class="container" tabindex="0">
+        <div class="container sibling-example-basic" tabindex="0">
           <span>Inbox</span>
           <paper-badge label="4"></paper-badge>
         </div>
 
-        <div class="container" tabindex="0">
+        <div class="container sibling-example-basic" tabindex="0">
           <span>Mood</span>
           <paper-badge icon="social:mood" label="happy"></paper-badge>
         </div>
@@ -75,7 +75,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             margin-left: 30px;
             margin-right: 30px;
           }
+          /** Space the badge away from its sibling. */
+          .sibling-example-basic > paper-badge {
+            --paper-badge-margin-left: 20px;
+            --paper-badge-margin-bottom: 0px;
+          }
         </style>
+      </template>
+    </demo-snippet>
+
+    <h3>Badges can be applied to siblings using superscripted positioning</h3>
+    <demo-snippet class="centered-demo">
+      <template>
+        <div class="container" tabindex="0">
+          <span>Mood</span>
+          <paper-badge id="superscripted" icon="social:mood" label="happy"></paper-badge>
+        </div>
+
+        <style is="custom-style">
+          .container {
+            display: inline-block;
+            margin-left: 30px;
+            margin-right: 30px;
+          }
+        </style>
+
+        <script>
+          document.querySelector('#superscripted')._usingSuperscript = true;
+        </script>
       </template>
     </demo-snippet>
 

--- a/paper-badge.html
+++ b/paper-badge.html
@@ -135,7 +135,7 @@ Custom property | Description | Default
          */
         for: {
           type: String,
-          observer: '_forChanged'
+          observer: '_updateTargetIfAttached'
         },
 
         /**
@@ -156,6 +156,18 @@ Custom property | Description | Default
         icon: {
           type: String,
           value: ''
+        },
+
+        /**
+         * When set, tells the element to position itself as superscript if a
+         * `for` attribute is not explicitly specified. This will be the default
+         * behavior in the next major release. This attribute is added here for
+         * backwards compatibility.
+         */
+        _usingSuperscript: {
+          type: Boolean,
+          value: false,
+          observer: '_updateTargetIfAttached'
         }
       },
 
@@ -169,15 +181,6 @@ Custom property | Description | Default
         }
       },
 
-      _forChanged: function() {
-        // The first time the property is set is before the badge is attached,
-        // which means we're not ready to position it yet.
-        if (!this.isAttached) {
-          return;
-        }
-        this._updateTarget();
-      },
-
       _labelChanged: function() {
         this.setAttribute('aria-label', this.label);
       },
@@ -188,24 +191,40 @@ Custom property | Description | Default
         this.async(this.notifyResize, 1);
       },
 
+      _updateTargetIfAttached: function() {
+        if (!this.isAttached) {
+          return;
+        }
+        this._updateTarget();
+      },
+
       _computeIsIconBadge: function(icon) {
         return icon.length > 0;
       },
 
       /**
        * Returns the target element that this badge is anchored to. It is
-       * either the element given by the `for` attribute, or null if no
-       * `for` attribute is specified. Note that we return null here instead
-       * of undefined in order to be consistent with the practices of standard
-       * DOM APIs, such as document.querySelector.
+       * either the element given by the `for` attribute, or the immediate
+       * parent of the badge _unless_ the `_usingSuperscript` property is set.
+       * If this is the case, target will return `null` if no `for` attribute
+       * is specified. In future releases, this will be the default behavior and
+       * badges without a `for` attribute specified will be positioned as
+       * superscript.
        */
       get target () {
         // If the parentNode is a document fragment, then we need to use the host.
+        var parentNode = Polymer.dom(this).parentNode;
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var target = null;
 
         if (this.for) {
           target = Polymer.dom(ownerRoot).querySelector('#' + this.for);
+        } else if (!this._usingSuperscript) {
+          // NOTE(traviskaufman): This functionality is being kept in order to
+          // keep the API backwards-compatible. It should be removed in the next
+          // major release.
+          target = parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
+              ownerRoot.host : parentNode;
         }
 
         return target;

--- a/paper-badge.html
+++ b/paper-badge.html
@@ -67,9 +67,13 @@ Custom property | Description | Default
   <template>
     <style>
       :host {
-        display: block;
-        position: absolute;
+        display: inline-block;
         outline: none;
+        vertical-align: super;
+      }
+
+      :host(.positioned) {
+        position: absolute;
       }
 
       :host([hidden]) {
@@ -180,6 +184,7 @@ Custom property | Description | Default
 
       _updateTarget: function() {
         this._target = this.target;
+        this.toggleClass('positioned', this._target != null);
         this.async(this.notifyResize, 1);
       },
 
@@ -189,20 +194,18 @@ Custom property | Description | Default
 
       /**
        * Returns the target element that this badge is anchored to. It is
-       * either the element given by the `for` attribute, or the immediate parent
-       * of the badge.
+       * either the element given by the `for` attribute, or null if no
+       * `for` attribute is specified. Note that we return null here instead
+       * of undefined in order to be consistent with the practices of standard
+       * DOM APIs, such as document.querySelector.
        */
       get target () {
-        var parentNode = Polymer.dom(this).parentNode;
         // If the parentNode is a document fragment, then we need to use the host.
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
-        var target;
+        var target = null;
 
         if (this.for) {
           target = Polymer.dom(ownerRoot).querySelector('#' + this.for);
-        } else {
-          target = parentNode.nodeType == Node.DOCUMENT_FRAGMENT_NODE ?
-              ownerRoot.host : parentNode;
         }
 
         return target;

--- a/test/basic.html
+++ b/test/basic.html
@@ -55,7 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template>
       <div>
         <div id="target">
-          <paper-badge label="1"></paper-badge>
+          <paper-badge for="target" label="1"></paper-badge>
         </div>
       </div>
     </template>
@@ -163,12 +163,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var badge = f.querySelector('paper-badge');
         badge.updatePosition();
 
-        expect(badge.target.getAttribute('id')).to.not.be.equal('target');
+        expect(badge.target).to.be.null;
 
         Polymer.Base.async(function() {
-          var contentRect = badge.getBoundingClientRect();
-          expect(contentRect.left).to.not.be.equal(100 - 11);
-
           badge.for = 'target';
           expect(badge.target.getAttribute('id')).to.be.equal('target');
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -163,6 +163,46 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var badge = f.querySelector('paper-badge');
         badge.updatePosition();
 
+        expect(badge.target.getAttribute('id')).to.not.be.equal('target');
+
+        Polymer.Base.async(function() {
+          var contentRect = badge.getBoundingClientRect();
+          expect(contentRect.left).to.not.be.equal(100 - 11);
+
+          badge.for = 'target';
+          expect(badge.target.getAttribute('id')).to.be.equal('target');
+
+          badge.updatePosition();
+
+          Polymer.Base.async(function() {
+            var divRect = f.querySelector('#target').getBoundingClientRect();
+            expect(divRect.width).to.be.equal(100);
+            expect(divRect.height).to.be.equal(20);
+
+            var contentRect = badge.getBoundingClientRect();
+            expect(contentRect.width).to.be.equal(20);
+            expect(contentRect.height).to.be.equal(20);
+
+            // The target div is 100 x 20, and the badge is centered on the
+            // top right corner.
+            expect(contentRect.left).to.be.equal(100 - 10);
+            expect(contentRect.top).to.be.equal(0 - 10);
+
+            // Also check the math, just in case.
+            expect(contentRect.left).to.be.equal(divRect.width - 10);
+            expect(contentRect.top).to.be.equal(divRect.top - 10);
+
+            done();
+          });
+        });
+      });
+
+      test('superscript badge is positioned correctly after being dynamically set', function(done) {
+        var f = fixture('dynamic');
+        var badge = f.querySelector('paper-badge');
+        badge._usingSuperscript = true;
+        badge.updatePosition();
+
         expect(badge.target).to.be.null;
 
         Polymer.Base.async(function() {


### PR DESCRIPTION
This commit modifies the default position of a badge element such that
if no target is given, the badge is simply superscripted to the element.