### PR TITLE
Include iron-positioning. Fixes label position when using Shadow DOM.

### DIFF
--- a/paper-badge.html
+++ b/paper-badge.html
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-styles/typography.html">
@@ -66,7 +67,7 @@ Custom property | Description | Default
 
 <dom-module id="paper-badge">
   <template>
-    <style>
+    <style include="iron-positioning">
       :host {
         display: block;
         position: absolute;


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-badge/issues/46.