### PR TITLE
Fix xref for iron-icon. Fixes #54.

### DIFF
--- a/paper-badge.html
+++ b/paper-badge.html
@@ -24,7 +24,7 @@ centered to the parent node containing it.
 Badges can also contain an icon by adding the `icon` attribute and setting
 it to the id of the desired icon. Please note that you should still set the
 `label` attribute in order to keep the element accessible. Also note that you will need to import
-the `iron-iconset` that includes the icons you want to use. See [iron-icon](../iron-icon)
+the `iron-iconset` that includes the icons you want to use. See [iron-icon](iron-icon)
 for more information on how to import and use icon sets.
 
 Example:


### PR DESCRIPTION
On the catalog, `../iron-icon` maps to a path of `https://elements.polymer-project.org/iron-icon` instead of [https://elements.polymer-project.org/elements/iron-icon](https://elements.polymer-project.org/elements/iron-icon).