### PR TITLE
Removed tab-index to fix issue #63: paper-badge has a tabindex while …

### DIFF
--- a/paper-badge.html
+++ b/paper-badge.html
@@ -113,8 +113,7 @@ Custom property | Description | Default
       is: 'paper-badge',
 
       hostAttributes: {
-        role: 'status',
-        tabindex: 0
+        role: 'status'
       },
 
       behaviors: [


### PR DESCRIPTION
This fixes #63 by removing the `tabindex` that should not be there.